### PR TITLE
Center qrcode for learning window

### DIFF
--- a/release/js/login.js
+++ b/release/js/login.js
@@ -2,8 +2,10 @@ chrome.runtime.sendMessage({"method": "chooseLogin"}, {}, function (response) {
     window.onload = function () {
 
         setTimeout(function () {
-            document.querySelector(".qrcode-box").scrollIntoView({
-                behavior: "smooth"
+            document.querySelector("#qglogin").scrollIntoView({
+                behavior: "smooth",
+                block: "center",
+                inline: "center",
             });
         }, 500);
 


### PR DESCRIPTION
For #26 , `scrollIntoView` to `#qglogin` instead `.qrcode-box` to centerize the login qrcode.